### PR TITLE
Fix/ejson money float amount

### DIFF
--- a/source/money.js
+++ b/source/money.js
@@ -15,7 +15,7 @@ Money = Space.domain.ValueObject.extend('Money', {
     if (arguments.length === 1 && typeof(arguments[0]) === 'object') {
       data = amount;
       // Calculate amount from base to avoid rounding issues
-      if (data.base && data.decimals) {
+      if (data.base !== undefined && data.decimals !== undefined) {
         this.amount = data.base / Math.pow(10, data.decimals);
       } else {
         check(data.amount, Number);

--- a/source/money.js
+++ b/source/money.js
@@ -16,19 +16,24 @@ Money = Space.domain.ValueObject.extend('Money', {
       data = amount;
       // Calculate amount from base to avoid rounding issues
       if (data.base && data.decimals) {
-        data.amount = data.base / Math.pow(10, data.decimals);
+        this.amount = data.base / Math.pow(10, data.decimals);
+      } else {
+        check(data.amount, Number);
+        this.amount = data.amount;
+        delete data.amount;
       }
     } else {
     // Creation with a params: amount, currency
-      data.amount = amount;
+      check(amount, Number);
+      this.amount = amount;
       data.currency = currency;
     }
     // Allow currency strings like 'EUR'
     if (!(data.currency instanceof Currency)) {
       data.currency = new Currency(data.currency || Money.DEFAULT_CURRENCY);
     }
-    data.decimals = this._decimalPlaces(data.amount);
-    data.base = data.amount * Math.pow(10, data.decimals);
+    data.decimals = this._decimalPlaces(this.amount);
+    data.base = this.amount * Math.pow(10, data.decimals);
     // Let the superclass check the data!
     Space.domain.ValueObject.call(this, data);
     Object.freeze(this);
@@ -40,7 +45,6 @@ Money = Space.domain.ValueObject.extend('Money', {
 
   fields() {
     return {
-      amount: Number,
       base: Match.Integer,
       decimals: Match.Integer,
       currency: Currency

--- a/tests/money.unit.js
+++ b/tests/money.unit.js
@@ -1,9 +1,12 @@
 describe("Money", function() {
 
   it('is serializable', function() {
-    let euro = new Money(9.9999, 'EUR');
-    let copy = EJSON.parse(EJSON.stringify(euro));
-    expect(copy.equals(euro)).to.be.true;
+    let original = new Money(9.9999, 'EUR');
+    let copy = EJSON.parse(EJSON.stringify(original));
+    expect(copy.base).to.equal(original.base);
+    expect(copy.decimals).to.equal(original.decimals);
+    expect(copy.amount).to.equal(original.amount);
+    expect(copy.currency.code).to.equal(original.currency.code);
   });
 
   describe('construction', function() {

--- a/tests/money.unit.js
+++ b/tests/money.unit.js
@@ -1,14 +1,5 @@
 describe("Money", function() {
 
-  it('is serializable', function() {
-    let original = new Money(9.9999, 'EUR');
-    let copy = EJSON.parse(EJSON.stringify(original));
-    expect(copy.base).to.equal(original.base);
-    expect(copy.decimals).to.equal(original.decimals);
-    expect(copy.amount).to.equal(original.amount);
-    expect(copy.currency.code).to.equal(original.currency.code);
-  });
-
   describe('construction', function() {
 
     it('takes a currency and value for construction', function() {
@@ -61,6 +52,27 @@ describe("Money", function() {
       expect(money + 5).to.equal(10);
     });
 
+  });
+
+  describe("serialization", function() {
+
+    it('supports decimal places', function() {
+      let original = new Money(9.9999, 'EUR');
+      let copy = EJSON.parse(EJSON.stringify(original));
+      expect(copy.base).to.equal(original.base);
+      expect(copy.decimals).to.equal(original.decimals);
+      expect(copy.amount).to.equal(original.amount);
+      expect(copy.currency.code).to.equal(original.currency.code);
+    });
+
+    it('handles 0 values correctly', function() {
+      let original = new Money(0, 'EUR');
+      let copy = EJSON.parse(EJSON.stringify(original));
+      expect(copy.base).to.equal(original.base);
+      expect(copy.decimals).to.equal(original.decimals);
+      expect(copy.amount).to.equal(original.amount);
+      expect(copy.currency.code).to.equal(original.currency.code);
+    });
   });
 
   describe('equality', function() {


### PR DESCRIPTION
this removes the `amount` property from EJSON serialization, since there are always rounding issues.
